### PR TITLE
[CthulhuTech_1ed] Fix Agility math to correctly roll AGI Feat

### DIFF
--- a/CthulhuTech_1ed/CthulhuTech_1_ed.html
+++ b/CthulhuTech_1ed/CthulhuTech_1_ed.html
@@ -252,7 +252,7 @@
                                     <td>Feat</td>
                                 </tr>
                                 <tr>
-                                    <th><button type="roll" class="sheet-feat_button" name="attr_feat_Agility" value="!ct [[ [[ @{Agi} ]]d10 ]] [[@{Agi}]] --|@{character_name} --Feat: Agility">Agility</button></th>
+                                    <th><button type="roll" class="sheet-feat_button" name="attr_feat_Agility" value="!ct [[ [[ floor([[@{Agi}]] /2) ]]d10 ]] [[@{Agi}]] --|@{character_name} --Feat: Agility">Agility</button></th>
                                     <td><input type="number" class="sheet-attribute1" name="attr_rating_Agi_total" value="[[@{Agi}]]" disabled/></td>
                                     <td><input type="number" class="sheet-attribute" name="attr_rating_Agi_base" value="0"/></td>
                                     <td><input type="number" class="sheet-attribute" name="attr_rating_Agi_mod" value="0"/></td>
@@ -307,7 +307,7 @@
                                     <td>Feat</td>
                                 </tr>
                                 <tr>
-                                    <th><button type="roll" class="sheet-feat_button" name="attr_feat-Agility_tager" value="!ct [[ [[ @{Agi} ]]d10 ]] [[@{Agi}]] --|@{character_name} --Feat: Agility">Agility</button></th>
+                                    <th><button type="roll" class="sheet-feat_button" name="attr_feat-Agility_tager" value="!ct [[ [[ floor([[@{Agi}]] /2) ]]d10 ]] [[@{Agi}]] --|@{character_name} --Feat: Agility">Agility</button></th>
                                     <td><input type="number" class="sheet-attribute_tager1" name="attr_Agi_total" value="[[@{Agi}]]" disabled/></td>
                                     <td><input type="number" class="sheet-attribute_tager" name="attr_rating_Agi_humanform" value="0"/></td>
                                     <td><input type="number" class="sheet-attribute_tager" name="attr_rating_Agi_tagerform" value="0"/></td>


### PR DESCRIPTION
Dice were counted by raw Agi instead of `floor(Agi / 2)` like all other attribute feat rolls.

## Changes / Comments

*Provide a few comments about what you have changed.*
AGI Feat was changed to calculate number of dice equal to raw AGI. This is incorrect and does not match how the other attribute feats are calculated. Dice count should equal `floor(AGI / 2)`



## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.